### PR TITLE
Fix/quest inventory

### DIFF
--- a/src/components/quest/Quests.vue
+++ b/src/components/quest/Quests.vue
@@ -43,7 +43,7 @@
 <script>
 import axios from "axios";
 
-import {getAllItemAddresses, getItem} from "@/utils/Items";
+import {getAllItemAddresses, getItem, GetTokenList} from "@/utils/Items";
 import Address from "@/components/generic/Address";
 import QuestsByQuest from "@/components/quest/QuestsByQuest";
 import QuestsByHero from "@/components/quest/QuestsByHero";
@@ -212,9 +212,11 @@ export default {
     }
   },
   created() {
+    GetTokenList()
     if (this.$route.params.userAddress) {
       this.userAddress = this.$route.params.userAddress
       this.loadQuests()
+
     }
   },
 }

--- a/src/utils/Items.js
+++ b/src/utils/Items.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import {ethers} from "ethers";
 
 const goldPriceImport = require("@/data/ItemGoldPrice.json")
 
@@ -22,10 +23,10 @@ export function GetTokenList() {
 }
 
 export function getItem(address) {
-    const addressLower = address.toLowerCase();
+    address = ethers.utils.getAddress(address);
     const _items = items.size > 0 ? items : mapItems()
     const item = {
-        ..._items.has(addressLower) ? _items.get(addressLower) : {name:"Unknown item", address}
+        ..._items.has(address) ? _items.get(address) : {name:"Unknown item", address}
     }
     const goldPrices = mappedGoldPrices()
 
@@ -51,7 +52,7 @@ export function getAllItemAddresses() {
 
 function mapItems() {
     for (let token of tokens) {
-        items.set(token.address.toLowerCase(), token)
+        items.set(token.address, token)
     }
     return items
 }

--- a/src/utils/Items.js
+++ b/src/utils/Items.js
@@ -22,9 +22,10 @@ export function GetTokenList() {
 }
 
 export function getItem(address) {
+    const addressLower = address.toLowerCase();
     const _items = items.size > 0 ? items : mapItems()
     const item = {
-        ..._items.has(address) ? _items.get(address) : {name:"Unknown item", address}
+        ..._items.has(addressLower) ? _items.get(addressLower) : {name:"Unknown item", address}
     }
     const goldPrices = mappedGoldPrices()
 
@@ -50,7 +51,7 @@ export function getAllItemAddresses() {
 
 function mapItems() {
     for (let token of tokens) {
-        items.set(token.address, token)
+        items.set(token.address.toLowerCase(), token)
     }
     return items
 }


### PR DESCRIPTION
Loading the Quests pane of Kingdom.watch was rendering all items as 'unknown item' and without any icons. 

It turns out that the tradescrow [JSON file](https://raw.githubusercontent.com/tradescrow/token-lists/main/build/tokens/tradescrow-dfk.tokenlist.json
) from which item info was sourced has irregular capitalization in its hex addresses-- note that some `b` characters are lower case and some are upper in `0xB57B60DeBDB0b8172bb6316a9164bd3C695F133a`.  If we store those addresses as lower case and access them that way, everything works. 

