### PR TITLE
New hero floor service plumbed in + various tweaks and fixes

### DIFF
--- a/src/components/about/FloorPrice.vue
+++ b/src/components/about/FloorPrice.vue
@@ -32,8 +32,8 @@
           <tbody>
           <tr>
             <td class="text-start">Generation</td>
-            <td class="text-start">G0, G1, G2, G3, G4+</td>
-            <td class="text-start">Generation 0, 1, 2, 3 are separate buckets. Generation 4+ is merged into one
+            <td class="text-start">G0, G1+</td>
+            <td class="text-start">Only Generation 0 is assessed separately now, all other generations are treated the same
               bucket.
             </td>
           </tr>
@@ -44,10 +44,14 @@
           </tr>
           <tr>
             <td class="text-start">Summons left</td>
-            <td class="text-start">S0, S1-4, S5-7, S8+, Si</td>
             <td class="text-start">
-              The buckets are currently 0, 1-4, 5-7, and 8-10 summons left. Gen0 heroes with unlimited summons has only
-              one bucket for infinite summons.
+					Basic: S0, S1-2, S3-5, S6-9, S10<br/>
+					Advanced: S0, S1, S2-4, S5<br/>
+					Elite: S0, S1, S3<br/>
+					Exalted: S0, S1<br/>
+				</td>
+            <td class="text-start">
+              The buckets vary based on the type of hero class.
             </td>
           </tr>
           <tr>
@@ -72,6 +76,25 @@
           </tr>
           </thead>
           <tbody>
+					<tr>
+						<td class="text-start">v0.4</td>
+						<td class="text-start">
+							<ul>
+								<li>
+									Hooked up to new API with slightly different logic.
+								</li>
+								<li>
+									Different summons buckets for class types (eg basic, advanded etc)
+								</li>
+								<li>
+									Only gen0 are assessed differently now.
+								</li>
+								<li>
+									Only Crystalvale market used currently. All prices in CRYSTAL.
+								</li>
+							</ul>
+						</td>
+					</tr>
           <tr>
             <td class="text-start">v0.3</td>
             <td class="text-start">
@@ -84,7 +107,6 @@
                 </li>
               </ul>
             </td>
-
           </tr>
           <tr>
             <td class="text-start">v0.2</td>

--- a/src/components/about/FloorPrice.vue
+++ b/src/components/about/FloorPrice.vue
@@ -21,6 +21,9 @@
           As it is rather important to understand what lie behind the floor price presented, a confidence rating is also
           provided. The keys are disclosed in the table below.
         </p>
+        <p class="text-start">
+          <i>Note: Currently only the Crystalvale Tavern (DFK Chain) is used for valuation. All floor values are in CRYSTAL.</i>
+        </p>
         <table class="table table-striped">
           <thead>
           <tr>

--- a/src/components/about/FloorPrice.vue
+++ b/src/components/about/FloorPrice.vue
@@ -45,11 +45,11 @@
           <tr>
             <td class="text-start">Summons left</td>
             <td class="text-start">
-					Basic: S0, S1-2, S3-5, S6-9, S10<br/>
-					Advanced: S0, S1, S2-4, S5<br/>
-					Elite: S0, S1, S3<br/>
-					Exalted: S0, S1<br/>
-				</td>
+              Basic: S0, S1-2, S3-5, S6-9, S10<br/>
+              Advanced: S0, S1, S2-4, S5<br/>
+              Elite: S0, S1, S3<br/>
+              Exalted: S0, S1<br/>
+            </td>
             <td class="text-start">
               The buckets vary based on the type of hero class.
             </td>
@@ -76,25 +76,25 @@
           </tr>
           </thead>
           <tbody>
-					<tr>
-						<td class="text-start">v0.4</td>
-						<td class="text-start">
-							<ul>
-								<li>
-									Hooked up to new API with slightly different logic.
-								</li>
-								<li>
-									Different summons buckets for class types (eg basic, advanded etc)
-								</li>
-								<li>
-									Only gen0 are assessed differently now.
-								</li>
-								<li>
-									Only Crystalvale market used currently. All prices in CRYSTAL.
-								</li>
-							</ul>
-						</td>
-					</tr>
+          <tr>
+            <td class="text-start">v0.4</td>
+            <td class="text-start">
+              <ul>
+                <li>
+                  Hooked up to new API with slightly different logic.
+                </li>
+                <li>
+                  Different summons buckets for class types (eg basic, advanded etc)
+                </li>
+                <li>
+                  Only gen0 are assessed differently now.
+                </li>
+                <li>
+                  Only Crystalvale market used currently. All prices in CRYSTAL.
+                </li>
+              </ul>
+            </td>
+          </tr>
           <tr>
             <td class="text-start">v0.3</td>
             <td class="text-start">

--- a/src/components/hero/Hero.vue
+++ b/src/components/hero/Hero.vue
@@ -113,51 +113,51 @@ export default {
     },
     async loadHeroes() {
       this.heroes = [];
-			const heroKeySet = [];
+      const heroKeySet = [];
 
-			let queryresults = await queryHeros(this.userAddress);
-			
-			this.heroTotal = 0;
+      let queryresults = await queryHeros(this.userAddress);
+      
+      this.heroTotal = 0;
 
-			for(let heroData of queryresults.heroes){
-				let hero = {...heroData};
+      for(let heroData of queryresults.heroes){
+        let hero = {...heroData};
 
-				hero.rarityString = rarity[hero.rarity];
-				hero.classString = mainClass[hero.mainClass];
-				hero.professionString = professionsMap[hero.profession];
-				
-				hero["minBeforeSummon"] = ((hero.nextSummonTime.valueOf() * 1000  - Date.now()) / 60000).toFixed(0);
-				hero["staminaFullIn"] = ((hero.staminaFullAt * 1000 - Date.now()) / 60000).toFixed(0)
-				hero["name"] = hero.firstName + " " + hero.lastName;
-				hero["bestProfession"] = "-";
-				hero["bestProfessionScore"] = 0;
-				hero["bestRelativeScore"] = 0;
-				hero["bestRelativeProfession"] = "-";
+        hero.rarityString = rarity[hero.rarity];
+        hero.classString = mainClass[hero.mainClass];
+        hero.professionString = professionsMap[hero.profession];
+        
+        hero["minBeforeSummon"] = ((hero.nextSummonTime.valueOf() * 1000  - Date.now()) / 60000).toFixed(0);
+        hero["staminaFullIn"] = ((hero.staminaFullAt * 1000 - Date.now()) / 60000).toFixed(0)
+        hero["name"] = hero.firstName + " " + hero.lastName;
+        hero["bestProfession"] = "-";
+        hero["bestProfessionScore"] = 0;
+        hero["bestRelativeScore"] = 0;
+        hero["bestRelativeProfession"] = "-";
 
-				hero["floorPrice"] = 0;
-				hero.heroKey = findHeroKey(hero);
-				heroKeySet.push(hero.heroKey);
-				
+        hero["floorPrice"] = 0;
+        hero.heroKey = findHeroKey(hero);
+        heroKeySet.push(hero.heroKey);
+        
         this.heroes.push(hero);
-			}
-			this.fetchFloors(heroKeySet);
+      }
+      this.fetchFloors(heroKeySet);
 
     },
-		async fetchFloors(keys){
-		const response = await axios.post("http://34.141.228.218:8081/herofloorBulk" 
-														, {"keys": keys} ,
-														{	headers: {
-																"Content-Type": "application/json",
-																'Access-Control-Allow-Origin': '*',
-															},
-														}
-													).catch(err => console.error(err));
-				this.heroes.forEach(hero => {
-					hero.floorPrice = response.data[hero.heroKey].floorPrice;
-					hero.floorConfidence = response.data[hero.heroKey].confidence;
-					this.heroTotal += hero.floorPrice;
-				});
-	},
+    async fetchFloors(keys){
+    const response = await axios.post("http://34.141.228.218:8081/herofloorBulk" 
+                            , {"keys": keys} ,
+                            {	headers: {
+                                "Content-Type": "application/json",
+                                'Access-Control-Allow-Origin': '*',
+                              },
+                            }
+                          ).catch(err => console.error(err));
+        this.heroes.forEach(hero => {
+          hero.floorPrice = response.data[hero.heroKey].floorPrice;
+          hero.floorConfidence = response.data[hero.heroKey].confidence;
+          this.heroTotal += hero.floorPrice;
+        });
+  },
     async fetchHeroData(heroId) {
       const hero = await heroesContract.getHero(heroId)
       console.info(hero)
@@ -242,7 +242,7 @@ export default {
           })
 
       // this.fetchFloor(true)
-			this.loadHeroes()
+      this.loadHeroes()
 
     } else {
       // this.fetchFloor(false)

--- a/src/components/hero/HeroGenes.vue
+++ b/src/components/hero/HeroGenes.vue
@@ -49,6 +49,7 @@
         <th class="text-start">Stat growth</th>
         <th class="text-end">Primary</th>
         <th class="text-end">Secondary</th>
+        <th class="text-end">Total</th>
       </tr>
       </thead>
       <tbody>
@@ -56,41 +57,49 @@
         <td class="text-start">{{ cap("agility")}}</td>
         <td class="text-end">{{ growth["p"]["agility"] }} %</td>
         <td class="text-end">{{ growth["s"]["agility"] }} %</td>
+        <td class="text-end">{{ growth["t"]["agility"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("dexterity")}}</td>
         <td class="text-end">{{ growth["p"]["dexterity"] }} %</td>
         <td class="text-end">{{ growth["s"]["dexterity"] }} %</td>
+        <td class="text-end">{{ growth["t"]["dexterity"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("endurance")}}</td>
         <td class="text-end">{{ growth["p"]["endurance"] }} %</td>
         <td class="text-end">{{ growth["s"]["endurance"] }} %</td>
+        <td class="text-end">{{ growth["t"]["endurance"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("intelligence")}}</td>
         <td class="text-end">{{ growth["p"]["intelligence"] }} %</td>
         <td class="text-end">{{ growth["s"]["intelligence"] }} %</td>
+        <td class="text-end">{{ growth["t"]["intelligence"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("luck")}}</td>
         <td class="text-end">{{ growth["p"]["luck"] }} %</td>
         <td class="text-end">{{ growth["s"]["luck"] }} %</td>
+        <td class="text-end">{{ growth["t"]["luck"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("strength")}}</td>
         <td class="text-end">{{ growth["p"]["strength"] }} %</td>
         <td class="text-end">{{ growth["s"]["strength"] }} %</td>
+        <td class="text-end">{{ growth["t"]["strength"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("vitality")}}</td>
         <td class="text-end">{{ growth["p"]["vitality"] }} %</td>
         <td class="text-end">{{ growth["s"]["vitality"] }} %</td>
+        <td class="text-end">{{ growth["t"]["vitality"] }} %</td>
       </tr>
       <tr>
         <td class="text-start">{{ cap("wisdom")}}</td>
         <td class="text-end">{{ growth["p"]["wisdom"] }} %</td>
         <td class="text-end">{{ growth["s"]["wisdom"] }} %</td>
+        <td class="text-end">{{ growth["t"]["wisdom"] }} %</td>
       </tr>
 
       </tbody>
@@ -118,20 +127,26 @@ export default {
       if(!heroData.id)
         return {
           p: {},
-          s: {}
+          s: {},
+					t: {}
         }
 
       const p = {}
       for (const [stat,growth] of Object.entries(heroData.pStatGrowth)) {
-        p[stat] = (growth / 100).toFixed(0)
+        p[stat] = (growth / 100).toFixed(2);
       }
 
       const s = {}
       for (const [stat,growth] of Object.entries(heroData.sStatGrowth)) {
-        s[stat] = (growth / 100).toFixed(0)
+        s[stat] = (growth / 100).toFixed(2);
       }
 
-      return {p,s}
+			const t = {}
+			for(const stat in p){
+				t[stat] = ((heroData.pStatGrowth[stat] + heroData.sStatGrowth[stat])/ 100).toFixed(2);
+			}
+
+      return {p,s,t}
 
     }
   },

--- a/src/components/hero/HeroGenes.vue
+++ b/src/components/hero/HeroGenes.vue
@@ -128,7 +128,7 @@ export default {
         return {
           p: {},
           s: {},
-					t: {}
+          t: {}
         }
 
       const p = {}
@@ -141,10 +141,10 @@ export default {
         s[stat] = (growth / 100).toFixed(2);
       }
 
-			const t = {}
-			for(const stat in p){
-				t[stat] = ((heroData.pStatGrowth[stat] + heroData.sStatGrowth[stat])/ 100).toFixed(2);
-			}
+      const t = {}
+      for(const stat in p){
+        t[stat] = ((heroData.pStatGrowth[stat] + heroData.sStatGrowth[stat])/ 100).toFixed(2);
+      }
 
       return {p,s,t}
 

--- a/src/components/hero/HeroList.vue
+++ b/src/components/hero/HeroList.vue
@@ -5,6 +5,9 @@
     <table class="table table-hover w-100">
       <thead>
       <tr>
+				<th class="text-start">Network
+          <SortIcon field="network"/>
+        </th>
         <th class="text-start">ID#
           <SortIcon field="id"/>
         </th>
@@ -56,20 +59,21 @@
       <tbody>
       <tr v-for="hero of sortedHeroes" :key="hero" @click="this.loadHero(hero.id)"
           :class="{'table-secondary': hero.id === selectedHeroId}">
-        <td class="text-start">{{ hero.id }}</td>
+				<td class="text-end">{{ hero.network }}</td>
+				<td class="text-start">{{ hero.id }}</td>
         <!--        <td />-->
         <!--        <td class="text-start">{{ hero.info.firstName }} {{ hero.info.lastName }} </td>-->
         <td class="text-end">{{ hero.generation }}</td>
         <td class="text-end">{{ hero.level }}</td>
-        <td class="text-start" :class="hero.rarity">{{ hero.rarity }}</td>
-        <td class="text-start">{{ hero.mainClass }}</td>
-        <td class="text-start">{{ cap(hero.profession) }}</td>
+        <td class="text-start" :class="hero.rarityString">{{ hero.rarityString }}</td>
+        <td class="text-start">{{ hero.classString }}</td>
+        <td class="text-start">{{ hero.professionString }}</td>
         <td class="text-start">{{ cap(hero.bestProfession) }}</td>
         <td class="text-end">{{ hero.bestProfessionScore }}</td>
         <td class="text-start">{{ cap(hero.bestRelativeProfession) }}</td>
         <td class="text-end">{{ hero.bestRelativeScore.toFixed(1) }} %</td>
         <td class="text-end">
-          <span v-if="hero.generation > 0">{{ hero.summonsLeft }}</span>
+          <span v-if="hero.generation > 0">{{ hero.summonsRemaining }}</span>
           <span v-else>&nbsp;&infin;</span>
         </td>
         <td class="text-end">
@@ -81,7 +85,7 @@
           <span v-else>Full</span>
         </td>
         <td class="text-end">{{ hero.xp }}</td>
-        <td class="text-end">{{ formatNumber(hero.floor.price) }}</td>
+        <td class="text-end">{{ formatNumber(hero.floorPrice) }}</td>
       </tr>
       </tbody>
       <tfoot>
@@ -101,6 +105,7 @@ import {capitalize} from "lodash";
 import SortIcon from "@/components/generic/SortIcon";
 
 const defaultSort = {
+	network: 0,
   id: 0,
   gen: 0,
   lvl: 0,
@@ -136,11 +141,22 @@ export default {
       else
         return heroData.id
     },
-    sortedHeroes() {
+		sortedHeroes() {
       const sortOrder = this.heroSort
       const heroes = [...this.heroes()]
 
-      if (sortOrder.id > 0)
+      if (sortOrder.network > 0)
+        heroes.sort((a, b) => {
+					if(a.network < b.network) return -1;
+					if(a.network > b.network) return 1;
+				})
+      else if (sortOrder.network < 0)
+        heroes.sort((a, b) => {
+					if(a.network > b.network) return -1;
+					if(a.network < b.network) return 1;
+				})
+
+			if (sortOrder.id > 0)
         heroes.sort((a, b) => a.id - b.id)
       else if (sortOrder.id < 0)
         heroes.sort((a, b) => b.id - a.id)
@@ -156,19 +172,19 @@ export default {
         heroes.sort((a, b) => b.level - a.level)
 
       if (sortOrder.rarity > 0)
-        heroes.sort((a, b) => a.rarityNum - b.rarityNum)
+        heroes.sort((a, b) => a.rarity - b.rarity)
       else if (sortOrder.rarity < 0)
-        heroes.sort((a, b) => b.rarityNum - a.rarityNum)
+        heroes.sort((a, b) => b.rarity - a.rarity)
 
       if (sortOrder.class> 0)
-        heroes.sort((a, b) => a.mainClass.localeCompare(b.mainClass))
+        heroes.sort((a, b) => a.classString.localeCompare(b.classString))
       else if (sortOrder.class < 0)
-        heroes.sort((a, b) => b.mainClass.localeCompare(a.mainClass))
+        heroes.sort((a, b) => b.classString.localeCompare(a.classString))
 
       if (sortOrder.greenProf> 0)
-        heroes.sort((a, b) => a.profession.localeCompare(b.profession))
+        heroes.sort((a, b) => a.professionString.localeCompare(b.professionString))
       else if (sortOrder.greenProf < 0)
-        heroes.sort((a, b) => b.profession.localeCompare(a.profession))
+        heroes.sort((a, b) => b.professionString.localeCompare(a.professionString))
 
       if (sortOrder.bestProf> 0)
         heroes.sort((a, b) => a.bestProfession.localeCompare(b.bestProfession))
@@ -212,9 +228,9 @@ export default {
         heroes.sort((a, b) => b.xp - a.xp)
 
       if (sortOrder.floor > 0)
-        heroes.sort((a, b) => a.floor.price - b.floor.price)
+        heroes.sort((a, b) => a.floorPrice - b.floorPrice)
       else if (sortOrder.floor < 0)
-        heroes.sort((a, b) => b.floor.price - a.floor.price)
+        heroes.sort((a, b) => b.floorPrice - a.floorPrice)
 
       return heroes
     },
@@ -226,7 +242,7 @@ export default {
 
       let total = 0
       for(const hero of heroes)
-        total += hero.floor.price
+        total += hero.floorPrice
 
       return total
     }

--- a/src/components/hero/HeroList.vue
+++ b/src/components/hero/HeroList.vue
@@ -5,7 +5,7 @@
     <table class="table table-hover w-100">
       <thead>
       <tr>
-				<th class="text-start">Network
+        <th class="text-start">Network
           <SortIcon field="network"/>
         </th>
         <th class="text-start">ID#
@@ -59,8 +59,8 @@
       <tbody>
       <tr v-for="hero of sortedHeroes" :key="hero" @click="this.loadHero(hero.id)"
           :class="{'table-secondary': hero.id === selectedHeroId}">
-				<td class="text-end">{{ hero.network }}</td>
-				<td class="text-start">{{ hero.id }}</td>
+        <td class="text-end">{{ hero.network }}</td>
+        <td class="text-start">{{ hero.id }}</td>
         <!--        <td />-->
         <!--        <td class="text-start">{{ hero.info.firstName }} {{ hero.info.lastName }} </td>-->
         <td class="text-end">{{ hero.generation }}</td>
@@ -105,7 +105,7 @@ import {capitalize} from "lodash";
 import SortIcon from "@/components/generic/SortIcon";
 
 const defaultSort = {
-	network: 0,
+  network: 0,
   id: 0,
   gen: 0,
   lvl: 0,
@@ -141,22 +141,22 @@ export default {
       else
         return heroData.id
     },
-		sortedHeroes() {
+    sortedHeroes() {
       const sortOrder = this.heroSort
       const heroes = [...this.heroes()]
 
       if (sortOrder.network > 0)
         heroes.sort((a, b) => {
-					if(a.network < b.network) return -1;
-					if(a.network > b.network) return 1;
-				})
+          if(a.network < b.network) return -1;
+          if(a.network > b.network) return 1;
+        })
       else if (sortOrder.network < 0)
         heroes.sort((a, b) => {
-					if(a.network > b.network) return -1;
-					if(a.network < b.network) return 1;
-				})
+          if(a.network > b.network) return -1;
+          if(a.network < b.network) return 1;
+        })
 
-			if (sortOrder.id > 0)
+      if (sortOrder.id > 0)
         heroes.sort((a, b) => a.id - b.id)
       else if (sortOrder.id < 0)
         heroes.sort((a, b) => b.id - a.id)

--- a/src/components/personal/Personal.vue
+++ b/src/components/personal/Personal.vue
@@ -189,7 +189,8 @@ export default {
       progressPct: { sd: 0, cv: 0, sd2: 0 },
       profileName: "",
       heroTotal: { sd: 0, cv: 0, sd2: 0 },
-      heroProgress: { sd: 0, cv: 100, sd2: 100 },
+      heroNumberof: { sd: 0, cv: 0, sd2: 0 },
+      heroProgress: { sd: 0, cv: 0, sd2: 0 },
       inventoryTotal: { sd: 0, cv: 0, sd2: 0 },
 			jewelPrice: 0
     }
@@ -288,6 +289,8 @@ export default {
 
       setHeroTotal: (total, expansion) => this.heroTotal[expansion] = total,
       heroTotal: (expansion) => this.heroTotal[expansion],
+			setHeroNumberof: (total, expansion) => this.heroNumberof[expansion] = total,
+      heroNumberof: (expansion) => this.heroNumberof[expansion],
       setHeroProgress: (pct, expansion) => {
         this.heroProgress[expansion] = pct
         this.calcProgressPct()

--- a/src/components/personal/Personal.vue
+++ b/src/components/personal/Personal.vue
@@ -192,7 +192,7 @@ export default {
       heroNumberof: { sd: 0, cv: 0, sd2: 0 },
       heroProgress: { sd: 0, cv: 0, sd2: 0 },
       inventoryTotal: { sd: 0, cv: 0, sd2: 0 },
-			jewelPrice: 0
+      jewelPrice: 0
     }
   },
   methods: {
@@ -235,8 +235,8 @@ export default {
         }
       }
       this.pricesTimestamp = Date.now()
-			this.jewelPrice = this.prices["JEWEL"];    
-		},
+      this.jewelPrice = this.prices["JEWEL"];    
+    },
   },
   computed: {
     blockTimeMeasurementString() {
@@ -256,7 +256,7 @@ export default {
 
       blockNumber: (expansion) => this.blockNumber[expansion],
       bankBalance: (expansion) => this.bankBalance[expansion],
-			jewelerBalance : (expansion) => this.jewelerBalance[expansion],
+      jewelerBalance : (expansion) => this.jewelerBalance[expansion],
 
       setBankBalance: (balance, expansion) => {
         this.bankBalance[expansion] = balance
@@ -289,7 +289,7 @@ export default {
 
       setHeroTotal: (total, expansion) => this.heroTotal[expansion] = total,
       heroTotal: (expansion) => this.heroTotal[expansion],
-			setHeroNumberof: (total, expansion) => this.heroNumberof[expansion] = total,
+      setHeroNumberof: (total, expansion) => this.heroNumberof[expansion] = total,
       heroNumberof: (expansion) => this.heroNumberof[expansion],
       setHeroProgress: (pct, expansion) => {
         this.heroProgress[expansion] = pct

--- a/src/components/personal/PersonalHeroes.vue
+++ b/src/components/personal/PersonalHeroes.vue
@@ -16,12 +16,12 @@
       </tr>
       </thead>
       <tbody v-for="[symbol, expansion] of [['Serendale', 'sd'], ['Crystalvale', 'cv'], ['Serendale 2.0', 'sd2']]" :key="symbol">
-				<tr>
-					<th>{{ symbol }} </th>
-					<td class="text-start" colspan="7">{{ heroes[expansion].length }} Heroes total. {{ priceStamp }}</td>
-					<th class="text-end"><img src="@/assets/dfk/crystal-logo.b0ad245d.png" style="width:22px !important"/><span>{{ formatNumber(heroTotal[expansion])}}</span></th>
-					<th/>
-				</tr>
+        <tr>
+          <th>{{ symbol }} </th>
+          <td class="text-start" colspan="7">{{ heroes[expansion].length }} Heroes total. {{ priceStamp }}</td>
+          <th class="text-end"><img src="@/assets/dfk/crystal-logo.b0ad245d.png" style="width:22px !important"/><span>{{ formatNumber(heroTotal[expansion])}}</span></th>
+          <th/>
+        </tr>
         <tr v-for="hero of heroes[expansion]" :key="hero">
           <td class="text-start">{{ hero.id }}</td>
           <td class="text-end">{{ hero.generation }}</td>
@@ -33,7 +33,7 @@
           <td class="text-start">{{ hero.maxSummons == 11 ? hero.summons :  hero.summonsRemaining }}/{{ hero.maxSummons == 11 ? "∞" : hero.maxSummons }}</td>
           <td class="text-end">{{ formatNumber(hero.floorPrice, null, null, 0)}}</td>
           <td class="text-start">{{ hero.floorConfidence }}</td>
-				</tr>
+        </tr>
       </tbody>
 
     </table>
@@ -49,9 +49,9 @@ import { expansionSet, expansionObjSet, expansionArraySet} from "@/utils/ethers"
 
 
 const networkMap = {
-	"hmy": "sd",
-	"dfk": "cv",
-	"kla": "sd2"
+  "hmy": "sd",
+  "dfk": "cv",
+  "kla": "sd2"
 }
 
 export default {
@@ -63,7 +63,7 @@ export default {
       heroes: {...expansionArraySet},
       floor: {...expansionObjSet},
       heroTotal: {...expansionSet},
-		heroNumberof:{...expansionSet}
+    heroNumberof:{...expansionSet}
     }
   },
   methods: {
@@ -71,76 +71,76 @@ export default {
       return formatNumber(num, prefix, suffix, decimals)
     },
     async fetchHeroes() {
-			const heroKeySet = [];
+      const heroKeySet = [];
 
-			for(let expansion in expansionSet){
-				this.heroTotal[expansion] = 0;
-				this.heroes[expansion] = [];
-			}
-			
-			let queryresults = await queryHeros(this.userAddress);
+      for(let expansion in expansionSet){
+        this.heroTotal[expansion] = 0;
+        this.heroes[expansion] = [];
+      }
+      
+      let queryresults = await queryHeros(this.userAddress);
 
-			const heroCount = queryresults.heroes.length;
+      const heroCount = queryresults.heroes.length;
 
-			let processedHeroes = 0
-			
-			for(let heroData of queryresults.heroes){
-				let hero = {...heroData};
-				// console.log(JSON.stringify(hero));
-				//set expansion
-				hero.expansion = networkMap[hero.network];
-				// map values to user friendly strings
-				hero.rarityString = rarity[hero.rarity];
-				hero.classString = mainClass[hero.mainClass];
-				hero.professionString = professionsMap[hero.profession];
-				hero.statBoost1String = choices.statBoost1[hero.statBoost1];
-				hero.statBoost2String = choices.statBoost2[hero.statBoost2];
+      let processedHeroes = 0
+      
+      for(let heroData of queryresults.heroes){
+        let hero = {...heroData};
+        // console.log(JSON.stringify(hero));
+        //set expansion
+        hero.expansion = networkMap[hero.network];
+        // map values to user friendly strings
+        hero.rarityString = rarity[hero.rarity];
+        hero.classString = mainClass[hero.mainClass];
+        hero.professionString = professionsMap[hero.profession];
+        hero.statBoost1String = choices.statBoost1[hero.statBoost1];
+        hero.statBoost2String = choices.statBoost2[hero.statBoost2];
 
-				//defaults for floor data
-				hero.floorPrice = 0;
-				hero.confidence = 'None';
-				//if for sale show that as value rather than floor
-				if(hero.salePrice) hero.floorPrice = hero.salePrice;
+        //defaults for floor data
+        hero.floorPrice = 0;
+        hero.confidence = 'None';
+        //if for sale show that as value rather than floor
+        if(hero.salePrice) hero.floorPrice = hero.salePrice;
        
-				//add to set for aggregated query
-				hero.heroKey = findHeroKey(hero);
-				heroKeySet.push(hero.heroKey);
+        //add to set for aggregated query
+        hero.heroKey = findHeroKey(hero);
+        heroKeySet.push(hero.heroKey);
 
-				// console.log(JSON.stringify(hero));
-				this.heroes[hero.expansion].push(hero)
+        // console.log(JSON.stringify(hero));
+        this.heroes[hero.expansion].push(hero)
 
         processedHeroes++
-				
+        
       }
-			for(let expansion of ["sd","cv","sd2"]){
-				
-				this.setHeroProgress(processedHeroes/heroCount * 100.0, expansion);
-				this.setHeroNumberof(this.heroes[expansion].length, [expansion])
-			}
-			
-		this.fetchFloors(heroKeySet);
+      for(let expansion of ["sd","cv","sd2"]){
+        
+        this.setHeroProgress(processedHeroes/heroCount * 100.0, expansion);
+        this.setHeroNumberof(this.heroes[expansion].length, [expansion])
+      }
+      
+    this.fetchFloors(heroKeySet);
     },
 
-	async fetchFloors(keys){
-		const response = await axios.post("http://34.141.228.218:8081/herofloorBulk" 
-														, {"keys": keys} ,
-														{	headers: {
-																"Content-Type": "application/json",
-																'Access-Control-Allow-Origin': '*',
-															},
-														}
-													).catch(err => console.error(err))
-													
-			for(let expansion of ['sd', 'cv', 'sd2']){
-				this.heroes[expansion].forEach(hero => {
-					hero.floorPrice = response.data[hero.heroKey].floorPrice;
-					hero.floorConfidence = response.data[hero.heroKey].confidence;
-					this.heroTotal[expansion] += hero.floorPrice;
-				});
-				this.setHeroTotal(this.heroTotal[expansion], [expansion])
-				this.setHeroProgress(100, [expansion])
-			}
-	},
+  async fetchFloors(keys){
+    const response = await axios.post("http://34.141.228.218:8081/herofloorBulk" 
+                            , {"keys": keys} ,
+                            {	headers: {
+                                "Content-Type": "application/json",
+                                'Access-Control-Allow-Origin': '*',
+                              },
+                            }
+                          ).catch(err => console.error(err))
+                          
+      for(let expansion of ['sd', 'cv', 'sd2']){
+        this.heroes[expansion].forEach(hero => {
+          hero.floorPrice = response.data[hero.heroKey].floorPrice;
+          hero.floorConfidence = response.data[hero.heroKey].confidence;
+          this.heroTotal[expansion] += hero.floorPrice;
+        });
+        this.setHeroTotal(this.heroTotal[expansion], [expansion])
+        this.setHeroProgress(100, [expansion])
+      }
+  },
   },
   computed: {
     priceStamp() {

--- a/src/components/personal/PersonalHeroes.vue
+++ b/src/components/personal/PersonalHeroes.vue
@@ -15,27 +15,26 @@
         <th class="text-start"><router-link to="/about/floorprice">Confidence</router-link></th>
       </tr>
       </thead>
-      <tbody v-for="[symbol, expansion] of [['Serendale', 'sd'], ['Crystalvale', 'cv']]" :key="symbol">
+      <tbody v-for="[symbol, expansion] of [['Serendale', 'sd'], ['Crystalvale', 'cv'], ['Serendale 2.0', 'sd2']]" :key="symbol">
+				<tr>
+					<th>{{ symbol }} </th>
+					<td class="text-start" colspan="7">{{ heroes[expansion].length }} Heroes total. {{ priceStamp }}</td>
+					<th class="text-end"><img src="@/assets/dfk/crystal-logo.b0ad245d.png" style="width:22px !important"/><span>{{ formatNumber(heroTotal[expansion])}}</span></th>
+					<th/>
+				</tr>
         <tr v-for="hero of heroes[expansion]" :key="hero">
           <td class="text-start">{{ hero.id }}</td>
-          <td class="text-end">{{ hero.info.generation }}</td>
-          <td class="text-end">{{ hero.state.level }}</td>
+          <td class="text-end">{{ hero.generation }}</td>
+          <td class="text-end">{{ hero.level }}</td>
           <td class="text-start" :class="hero.rarityString">{{ hero.rarityString }}</td>
           <td class="text-start">{{ hero.classString }}</td>
           <td class="text-start">{{ hero.professionString }}</td>
-          <td class="text-start d-flex"><div class="Uncommon">{{ hero.statBoost1 }}</div> / <div class="Rare">{{ hero.statBoost2 }}</div></td>
-          <td class="text-start">{{ hero.summoningInfo.maxSummons - hero.summoningInfo.summons }}/{{ hero.summoningInfo.maxSummons }}</td>
+          <td class="text-start d-flex"><div class="Uncommon">{{  hero.statBoost1String }}</div> / <div class="Rare">{{ hero.statBoost2String }}</div></td>
+          <td class="text-start">{{ hero.maxSummons == 11 ? hero.summons :  hero.summonsRemaining }}/{{ hero.maxSummons == 11 ? "∞" : hero.maxSummons }}</td>
           <td class="text-end">{{ formatNumber(hero.floorPrice, null, null, 0)}}</td>
           <td class="text-start">{{ hero.floorConfidence }}</td>
-        </tr>
+				</tr>
       </tbody>
-      <tfoot>
-      <tr>
-        <td class="text-start" colspan="8">{{ heroes.sd.length }} Heroes total. {{ priceStamp }}</td>
-        <th class="text-end">{{ formatNumber(heroTotal.sd)}}</th>
-        <th />
-      </tr>
-      </tfoot>
 
     </table>
   </div>
@@ -44,22 +43,27 @@
 <script>
 import axios from "axios";
 import formatNumber from "@/utils/FormatNumber";
-import {getStatGenes, mainClass} from "@/utils/Heroes";
+import {rarity, mainClass, choices, queryHeros, professionsMap, findHeroKey} from "@/utils/Heroes";
 
-import {contracts, expansionSet, expansionObjSet, expansionArraySet, formatUnits} from "@/utils/ethers";
+import { expansionSet, expansionObjSet, expansionArraySet} from "@/utils/ethers";
 
-const rarity = ["Common", "Uncommon", "Rare", "Legendary", "Mythic"]
 
+const networkMap = {
+	"hmy": "sd",
+	"dfk": "cv",
+	"kla": "sd2"
+}
 
 export default {
   name: "PersonalHeroes",
   props: ["userAddress"],
-  inject: ["setHeroTotal", "setHeroProgress"],
+  inject: ["setHeroTotal", "setHeroProgress","setHeroNumberof"],
   data() {
     return {
       heroes: {...expansionArraySet},
       floor: {...expansionObjSet},
-      heroTotal: {...expansionSet}
+      heroTotal: {...expansionSet},
+		heroNumberof:{...expansionSet}
     }
   },
   methods: {
@@ -67,71 +71,76 @@ export default {
       return formatNumber(num, prefix, suffix, decimals)
     },
     async fetchHeroes() {
-      this.heroes.sd = []
-      const heroIdsRaw = await contracts.cv.hero.getUserHeroes(this.userAddress)
-      const heroIds = heroIdsRaw.map(heroId => Number(formatUnits(heroId, 0)))
+			const heroKeySet = [];
 
-      const auctionHeroIdsRaw = await contracts.cv.auction.getUserAuctions(this.userAddress)
-      const auctionHeroIds = auctionHeroIdsRaw.map(heroId => Number(formatUnits(heroId, 0)))
+			for(let expansion in expansionSet){
+				this.heroTotal[expansion] = 0;
+				this.heroes[expansion] = [];
+			}
+			
+			let queryresults = await queryHeros(this.userAddress);
 
-      const combinedHeroIds = heroIds.concat(auctionHeroIds)
+			const heroCount = queryresults.heroes.length;
 
-      const heroCount = combinedHeroIds.length
+			let processedHeroes = 0
+			
+			for(let heroData of queryresults.heroes){
+				let hero = {...heroData};
+				// console.log(JSON.stringify(hero));
+				//set expansion
+				hero.expansion = networkMap[hero.network];
+				// map values to user friendly strings
+				hero.rarityString = rarity[hero.rarity];
+				hero.classString = mainClass[hero.mainClass];
+				hero.professionString = professionsMap[hero.profession];
+				hero.statBoost1String = choices.statBoost1[hero.statBoost1];
+				hero.statBoost2String = choices.statBoost2[hero.statBoost2];
 
-      let processedHeroes = 0
-      this.heroTotal.sd = 0
+				//defaults for floor data
+				hero.floorPrice = 0;
+				hero.confidence = 'None';
+				//if for sale show that as value rather than floor
+				if(hero.salePrice) hero.floorPrice = hero.salePrice;
+       
+				//add to set for aggregated query
+				hero.heroKey = findHeroKey(hero);
+				heroKeySet.push(hero.heroKey);
 
-      for (let heroId of combinedHeroIds) {
-
-        const rawHero = await contracts.cv.hero.getHero(heroId)
-
-        const [statGenes, ] = getStatGenes(rawHero.info.statGenes)
-        const floorData = this.floorPrice(rawHero, statGenes.profession)
-
-        this.heroTotal.sd += floorData.price
-
-        let hero = {...rawHero}
-        hero.statBoost1 = statGenes.statBoost1
-        hero.statBoost2 = statGenes.statBoost2
-        hero.floorPrice = floorData.price
-        hero.floorConfidence = floorData.confidence
-
-        hero.rarityString = rarity[hero.info.rarity]
-
-        console.log(`hero.info.class 10: ${hero.info.class} 16: ${parseInt(hero.info.class, 16)} => ${mainClass[hero.info.class]}`)
-        hero.classString = mainClass[hero.info.class]
-        hero.professionString = statGenes.profession.charAt(0).toUpperCase() + statGenes.profession.substring(1)
-
-        this.heroes.sd.push(hero)
+				// console.log(JSON.stringify(hero));
+				this.heroes[hero.expansion].push(hero)
 
         processedHeroes++
-        this.setHeroProgress(processedHeroes/heroCount * 100.0, 'sd')
+				
       }
-
-      this.setHeroTotal(this.heroTotal.sd, 'sd')
-      this.setHeroProgress(100, 'sd')
+			for(let expansion of ["sd","cv","sd2"]){
+				
+				this.setHeroProgress(processedHeroes/heroCount * 100.0, expansion);
+				this.setHeroNumberof(this.heroes[expansion].length, [expansion])
+			}
+			
+		this.fetchFloors(heroKeySet);
     },
 
-    async fetchFloor() {
-      const response = await axios.get("https://us-east1-dfkwatch-328521.cloudfunctions.net/heroFloor")
-          .catch(err => console.error(err))
-
-      if (response.status !== 200)
-          return console.error(response.statusText)
-
-      this.floor.sd = response.data
-
-      await this.fetchHeroes()
-
-    },
-    floorPrice(hero, profession) {
-      console.log(`Not getting the floor price of ${hero} profession ${profession}`)
-
-      return {
-        confidence: "None",
-        price: 0
-      }
-    },
+	async fetchFloors(keys){
+		const response = await axios.post("http://34.141.228.218:8081/herofloorBulk" 
+														, {"keys": keys} ,
+														{	headers: {
+																"Content-Type": "application/json",
+																'Access-Control-Allow-Origin': '*',
+															},
+														}
+													).catch(err => console.error(err))
+													
+			for(let expansion of ['sd', 'cv', 'sd2']){
+				this.heroes[expansion].forEach(hero => {
+					hero.floorPrice = response.data[hero.heroKey].floorPrice;
+					hero.floorConfidence = response.data[hero.heroKey].confidence;
+					this.heroTotal[expansion] += hero.floorPrice;
+				});
+				this.setHeroTotal(this.heroTotal[expansion], [expansion])
+				this.setHeroProgress(100, [expansion])
+			}
+	},
   },
   computed: {
     priceStamp() {
@@ -144,7 +153,8 @@ export default {
     }
   },
   mounted() {
-    this.fetchFloor()
+   //  this.fetchFloor()
+    this.fetchHeroes();
   }
 }
 </script>

--- a/src/components/personal/PersonalInventory.vue
+++ b/src/components/personal/PersonalInventory.vue
@@ -11,7 +11,7 @@
             <th class="text-start">Item<SortIcon field="name"/></th>
             <th class="text-end">Balance<SortIcon field="balance"/></th>
             <th class="text-end">Jewel Price<SortIcon field="price"/></th>
-            <th class="text-end">Jewels<SortIcon field="jewels"/></th>
+            <th class="text-end">Jewels<SortIcon field="totalJewel"/></th>
             <th class="text-end">Jewel USD</th>
             <th class="text-end">Gold Price<SortIcon field="priceGold"/></th>
             <th class="text-end">Gold<SortIcon field="gold"/></th>
@@ -59,13 +59,13 @@
     <thead>
       <tr>
         <th/>
-        <th class="text-start">Item<SortIcon field="name"/></th>
-        <th class="text-end">Balance<SortIcon field="balance"/></th>
-        <th class="text-end">Jewel Price<SortIcon field="price"/></th>
-        <th class="text-end">Jewels<SortIcon field="jewels"/></th>
+        <th class="text-start">Item</th>
+        <th class="text-end">Balance</th>
+        <th class="text-end">Jewel Price</th>
+        <th class="text-end">Jewels</th>
         <th class="text-end">Jewel USD</th>
-        <th class="text-end">Gold Price<SortIcon field="priceGold"/></th>
-        <th class="text-end">Gold<SortIcon field="gold"/></th>
+        <th class="text-end">Gold Price</th>
+        <th class="text-end">Gold</th>
         <th class="text-end">Gold USD</th>
       </tr>
     </thead>
@@ -95,6 +95,7 @@ const defaultSort = {
   name: 0,
   balance: 0,
   price: 0,
+  totalJewel: 0,
   jewels: 0,
   priceGold: 0,
   gold: 0,
@@ -204,14 +205,14 @@ export default {
         items.sort((a, b) => b.name.localeCompare(a.name))
 
       else if (sortOrder.price > 0)
-        items.sort((a, b) => a.price - b.price)
+        items.sort((a, b) => a.jewelPrice - b.jewelPrice)
       else if (sortOrder.price < 0)
-        items.sort((a, b) => b.price - a.price)
+        items.sort((a, b) => b.jewelPrice - a.jewelPrice)
 
-      else if (sortOrder.jewels > 0)
-        items.sort((a, b) => a.jewels - b.jewels)
-      else if (sortOrder.jewels < 0)
-        items.sort((a, b) => b.jewels - a.jewels)
+      else if (sortOrder.totalJewel > 0)
+        items.sort((a, b) => a.totalJewel - b.totalJewel)
+      else if (sortOrder.totalJewel < 0)
+        items.sort((a, b) => b.totalJewel - a.totalJewel)
 
       else if (sortOrder.priceGold > 0)
         items.sort((a, b) => a.goldPrice - b.goldPrice)
@@ -219,9 +220,9 @@ export default {
         items.sort((a, b) => b.goldPrice - a.goldPrice)
 
       else if (sortOrder.gold > 0)
-        items.sort((a, b) => a.gold - b.gold)
+        items.sort((a, b) => a.totalGold - b.totalGold)
       else if (sortOrder.gold < 0)
-        items.sort((a, b) => b.gold - a.gold)
+        items.sort((a, b) => b.totalGold - a.totalGold)
       else
         items.sort((a, b) => a.name.localeCompare(b.name))
       return items;

--- a/src/components/personal/PersonalOverview.vue
+++ b/src/components/personal/PersonalOverview.vue
@@ -68,23 +68,26 @@
         <tr><td colspan="3"></td></tr>
 
         <tr>
-          <td class="text-start" colspan="2">
+          <td class="text-start" >
             <span class="form-check form-switch">
               <input v-model="includeHeroes" class="form-check-input" type="checkbox" role="switch" id="flexSwitchHeroes">
               <label class="form-check-label" for="flexSwitchHeroes">Heroes</label>
             </span>
           </td>
+					<th class="text-end">
+            <span>{{  includeHeroes ? (heroNumberof('sd')+heroNumberof('cv')+heroNumberof('sd2')) : "" }}</span>
+          </th>
           <th class="text-end">
-            {{ formatNumber(includeHeroes?(heroTotal('sd')*tokenPrice('sd'))+(heroTotal('cv') * tokenPrice('cv')):0, '$') }}
+            {{ formatNumber(includeHeroes?(heroTotal('sd')*tokenPrice('cv'))+(heroTotal('cv') * tokenPrice('cv')+(heroTotal('sd2') * tokenPrice('cv'))):0, '$') }}
           </th>
         </tr>
         <tr v-for="[symbol, expansion] of [['Serendale', 'sd'], ['Crystalvale', 'cv'], ['Serendale 2.0', 'sd2']]" :key="symbol">
           <td class="text-start ps-5">{{ symbol }}</td>
           <td class="text-end">
-            <span>{{ formatNumber(includeHeroes ? heroTotal(expansion) : 0) }}</span>
+            <span>{{ includeHeroes ? heroNumberof(expansion) : 0 }}</span>
           </td>
           <td class="text-end">
-            <span>{{ formatNumber(includeHeroes ? heroTotal(expansion) * tokenPrice(expansion) : 0, '$') }}</span>
+            <span>{{ formatNumber(includeHeroes ? heroTotal(expansion) * tokenPrice('cv') : 0, '$') }}</span>
           </td>
         </tr>
 
@@ -309,7 +312,7 @@
         <tr>
           <th class="text-start" colspan="2">Hero Floor</th>
           <th class="text-end">
-            {{ formatNumber((heroTotal('sd')*tokenPrice('sd'))+(heroTotal('cv')*tokenPrice('cv')), '$') }}
+            {{ formatNumber((heroTotal('sd')*tokenPrice('cv'))+(heroTotal('cv')*tokenPrice('cv'))+(heroTotal('sd2')*tokenPrice('cv')), '$') }}
           </th>
         </tr>
         </thead>
@@ -321,7 +324,7 @@
         <tr v-for="[symbol, expansion] of [['Serendale', 'sd'], ['Crystalvale', 'cv'], ['Serendale 2.0', 'sd2']]" :key="symbol">
           <th class="text-start ps-5">{{ symbol }}</th>
           <th class="text-end">{{ formatNumber(heroTotal(expansion)) }}</th>
-          <th class="text-end">{{ formatNumber(heroTotal(expansion) * tokenPrice(expansion), '$') }}</th>
+          <th class="text-end">{{ formatNumber(heroTotal(expansion) * tokenPrice('cv'), '$') }}</th>
         </tr>
         <tr>
           <td colspan="3">&nbsp;</td>
@@ -410,7 +413,7 @@ export default {
       }
     }
   },
-  inject: [ "totalPending", "epoch", "bankBalance", "prices", "progressPct", "pools", "heroTotal", "inventoryTotal", "jewelerBalance"],
+  inject: [ "totalPending", "epoch", "bankBalance", "prices", "progressPct", "pools", "heroTotal", "inventoryTotal", "jewelerBalance","heroNumberof"],
   methods: {
     formatNumber(num, prefix) {
       return formatNumber(num, prefix)
@@ -446,7 +449,7 @@ export default {
       if (this.includeLocked)
         grandTotal += this.totalLocked(expansion) * this.tokenPrice(expansion)
       if (this.includeHeroes)
-        grandTotal += this.heroTotal(expansion) * this.tokenPrice(expansion)
+        grandTotal += this.heroTotal(expansion) * this.tokenPrice('cv') // all heroes priced in crystal atm
       if(this.includeInventory)
         grandTotal += this.inventoryTotal(expansion) * this.tokenPrice('sd') // all demoninated in JEWEL atm - maybe change this
         grandTotal += this.totalPoolUsd(expansion)

--- a/src/data/dfk.tokenlist.dfkchain.json
+++ b/src/data/dfk.tokenlist.dfkchain.json
@@ -106,17 +106,6 @@
     },
 	 {
       "chainId": 53935,
-      "address": "0x576C260513204392F0eC0bc865450872025CB1cA",
-      "symbol": "DFKGOLD",
-      "name": "Gold",
-      "decimals": 3,
-      "logoURI": "https://dfk-hv.b-cdn.net/art-assets/items/gold-bag.png",
-      "tags": [
-        "dfk chain"
-      ]
-    },
-	 {
-      "chainId": 53935,
       "address": "0xB78d5580d6D897DE60E1A942A5C1dc07Bc716943",
       "symbol": "DFKAMBRTFY",
       "name": "Ambertaffy",
@@ -480,7 +469,7 @@
     },
     {
       "chainId": 53935,
-      "address": "0xd37aCbAC3C25a543B30aa16208637cfa6EB97eDd",
+      "address": "0xF1D53fa23C562246B9d8EC591eEa12Ec0288a888",
       "symbol": "DFKLFINST",
       "name": "Lesser Finesse Stone",
       "decimals": 0,
@@ -1034,7 +1023,7 @@
       "symbol": "DFKSHAGCAP",
       "name": "Shaggy Caps",
       "decimals": 0,
-      "logoURI": "https://defi-kingdoms.b-cdn.net/art-assets/items/threeEyedEel.png",
+      "logoURI": "https://defi-kingdoms.b-cdn.net/art-assets/items/shaggyCaps.png",
       "tags": [
         "dfk chain"
       ]

--- a/src/data/dfk.tokenlist.klaytn.json
+++ b/src/data/dfk.tokenlist.klaytn.json
@@ -3,17 +3,6 @@
   "tokens": [
 	 {
       "chainId": 8217,
-      "address": "0xe7a1B580942148451E47b92e95aEB8d31B0acA37",
-      "symbol": "DFKGOLD",
-      "name": "Gold",
-      "decimals": 3,
-      "logoURI": "https://dfk-hv.b-cdn.net/art-assets/items/gold-bag.png",
-      "tags": [
-        "klaytn"
-      ]
-    },
-	 {
-      "chainId": 8217,
       "address": "0x75E8D8676d774C9429FbB148b30E304b5542aC3d",
       "symbol": "DFKAMBRTFY",
       "name": "Ambertaffy",
@@ -865,7 +854,7 @@
       "symbol": "DFKSHAGCAP",
       "name": "Shaggy Caps",
       "decimals": 0,
-      "logoURI": "https://defi-kingdoms.b-cdn.net/art-assets/items/threeEyedEel.png",
+      "logoURI": "https://defi-kingdoms.b-cdn.net/art-assets/items/shaggyCaps.png",
       "tags": [
         "klaytn"
       ]

--- a/src/utils/Heroes.js
+++ b/src/utils/Heroes.js
@@ -1,5 +1,7 @@
 import {hexToNumber} from "@harmony-js/utils";
 import {valuateAllProfessions} from "@/utils/HeroValuation";
+import { GraphQLClient, gql } from 'graphql-request';
+
 
 export const stats = new Map()
 stats.set("AGI", "agility")
@@ -278,7 +280,7 @@ const statsGenesMap = {
     10: 'element',
     11: 'statsUnknown2'
 }
-const choices = {
+export const choices = {
     gender: {1: 'male', 3: 'female'},
     background: {
         0: 'desert',
@@ -600,6 +602,116 @@ const choices = {
     }
 }
 
+export const professionsMap = {
+  0: 'Mining',
+  2: 'Gardening',
+  4: 'Fishing',
+  6: 'Foraging'
+}
+
+
+const graphqlapiUrl = 'https://defi-kingdoms-community-api-gateway-co06z8vi.uc.gateway.dev/graphql';
+
+const heroQuery =  
+      gql`
+        query getHeroes($ownerAddress: String!){
+          heroes(
+          where: {
+            owner: $ownerAddress
+          }) {
+            id
+            firstName
+            lastName
+            mainClass
+            rarity
+            level
+            generation
+            network
+            summonsRemaining
+            maxSummons
+            summons
+            profession
+            salePrice
+            statBoost1
+            statBoost2
+            nextSummonTime
+            staminaFullAt
+            xp
+          }
+        }`;
+
+export async function queryHeros(address){
+  const client = new GraphQLClient(graphqlapiUrl);
+  return await client.request(heroQuery, {ownerAddress: address});
+}
+
+export function mainClassType(classId){
+  if(classId < 16){
+    return "basic";
+  }
+  else if(classId < 24){
+    return "advanced";
+  }
+  else if(classId < 28){
+    return "elite";
+  }
+  else if(classId === 28){
+    return "exalted";
+  }
+}
+
+export function findSummonsbucket(summons, classtype){
+  if(classtype==="basic"){
+    switch(summons){
+      case 0:
+        return "0";
+      case 1:
+      case 2:
+        return "1-2";
+      case 3:
+      case 4:
+      case 5:
+        return "3-5";
+      case 6:
+      case 7:
+      case 8:
+      case 9:
+        return "6-9";
+      case 10:
+        return "10";
+    }
+  }
+  else if(classtype==="advanced"){
+    switch(summons){
+      case 0:
+        return "0";
+      case 1:
+        return "1";
+      case 2:
+      case 3:
+      case 4:
+        return "2-4";
+      case 5:
+        return "5";
+    }
+  }
+  else if(classtype==="elite" || classtype==="exalted"){
+    return summons.toString();
+  }
+}
+
+export function findHeroKey(hero){
+  if(hero.generation == 0){
+    //gen0s assessed differently
+    return "gen0:" + hero.mainClass + ':' + hero.rarity;
+  }
+  else{
+    // key for api = mainClass:profession:rarity:summons
+    let summonkey = findSummonsbucket(hero.summonsRemaining, mainClassType( hero.mainClass));
+    return hero.mainClass + ':' + hero.profession + ':' + hero.rarity + ":" + summonkey;
+  }
+}
+
 function kai2dec(kai) {
     const ALPHABET = '123456789abcdefghijkmnopqrstuvwx'
     return ALPHABET.indexOf(kai)
@@ -669,10 +781,10 @@ export function extractHeroData(hero, maxScores) {
     heroData["rarity"] = rarity[hero.info.rarity]
     heroData["rarityNum"] = hero.info.rarity
 
-    console.log(`hero.info.class 10: ${hero.info.class} 16: ${parseInt(hero.info.class, 16)} => ${mainClass[hero.info.class]}`)
+    // console.log(`hero.info.class 10: ${hero.info.class} 16: ${parseInt(hero.info.class, 16)} => ${mainClass[hero.info.class]}`)
     heroData["mainClass"] = mainClass[hero.info.class]
 
-    console.log(`hero.info.subClass 10: ${hero.info.subClass} 16: ${parseInt(hero.info.subClass, 16)} => ${mainClass[hero.info.subClass]}`)
+    // console.log(`hero.info.subClass 10: ${hero.info.subClass} 16: ${parseInt(hero.info.subClass, 16)} => ${mainClass[hero.info.subClass]}`)
     heroData["subClass"] = mainClass[hero.info.subClass]
 
     heroData["name"] = `${hero.info.firstName} ${hero.info.lastName}`
@@ -689,11 +801,11 @@ export function extractHeroData(hero, maxScores) {
     heroData["sStatGrowth"] = {}
 
     for (const [stat, hexValue] of Object.entries(hero.primaryStatGrowth)) {
-        heroData["pStatGrowth"][stat] = hexToNumber("0x" + hexValue)
+        heroData["pStatGrowth"][stat] = hexValue;
     }
 
     for (const [stat, hexValue] of Object.entries(hero.secondaryStatGrowth)) {
-        heroData["sStatGrowth"][stat] = hexToNumber("0x" + hexValue)
+        heroData["sStatGrowth"][stat] = hexValue
     }
 
 
@@ -712,7 +824,7 @@ export function extractHeroData(hero, maxScores) {
     try {
         profScore = valuateAllProfessions(heroData)
     } catch (e) {
-        console.log(`Valuation gave excpetion ${e}`)
+        console.log(`Valuation gave exception ${e}`)
     }
     heroData["bestRelativeScore"] = 0
     heroData["bestRelativeProfession"] = ""


### PR DESCRIPTION
### New hero floor put in
- changes to how keys for heroes are constructed
- now assemble required keys and request after heroes have loaded
- different endpoint
- updated floor price page to reflect changes
### Other hero adjustments
- Now using the GraphQL API to get hero data in bulk as rpc requests were v slow for large rosters
- Updated on personal page and hero page
- hooked into Overview too
### bug fixes
- fixed growth stat values on hero page (+ added total column)
- fixed column sorting for inventory
- fixed shaggy caps image
- corrected lesser finesse stone contract address
