### PR TITLE
Inventory Fixes

### DIFF
--- a/src/components/personal/PersonalInventory.vue
+++ b/src/components/personal/PersonalInventory.vue
@@ -245,9 +245,9 @@ export default {
             && pair.priceUsd
         )
         if (pairs?.length > 0){
-					if(itemDetails.symbol === "DFKGOLD" && chainId === "avalanchedfk") console.log(pairs[0]) // here to try and catch intermittent bug where CV gold price get set as Infinity
-					return Number(pairs[0].priceUsd)
-				}
+          if(itemDetails.symbol === "DFKGOLD" && chainId === "avalanchedfk") console.log(pairs[0]) // here to try and catch intermittent bug where CV gold price get set as Infinity
+          return Number(pairs[0].priceUsd)
+        }
       } else {
         console.log(`Got status ${r.status} : ${r.statusText} while loading prices`)
       }

--- a/src/components/personal/PersonalInventory.vue
+++ b/src/components/personal/PersonalInventory.vue
@@ -3,7 +3,7 @@
   <div v-for="[symbol, expansion] of [['Serendale (Harmony)', 'sd'], ['Crystalvale (DFKChain)', 'cv'], ['Serendale 2.0 (Klatyn)', 'sd2']]" :key="symbol">
     <h3>{{symbol}}</h3>
     <hr/>
-    <div v-if="items[expansion].length > 1">
+    <div v-if="items[expansion].length > 1 || items[expansion][0].balance != 0">
       <table class="table table-hover w-100">
         <thead>
           <tr>

--- a/src/components/personal/PersonalInventory.vue
+++ b/src/components/personal/PersonalInventory.vue
@@ -3,7 +3,7 @@
   <div v-for="[symbol, expansion] of [['Serendale (Harmony)', 'sd'], ['Crystalvale (DFKChain)', 'cv'], ['Serendale 2.0 (Klatyn)', 'sd2']]" :key="symbol">
     <h3>{{symbol}}</h3>
     <hr/>
-    <div v-if="items[expansion].length > 1 || items[expansion][0].balance != 0">
+    <div v-if="items[expansion].length > 1 || items[expansion][0]?.balance != 0">
       <table class="table table-hover w-100">
         <thead>
           <tr>


### PR DESCRIPTION
- Fix to handle missing harmony gold price (dexscreener is returning null pairs so cant get valuation and this blocks the rest of the items from loading) 
  - Just put in a safe nav operator as a quick fix for now (long term probably look to deprecate harmony)
  - This also allows non-appraisable items (eg greater stones with no LP etc) to show, which was a bug I didnt know was there.
- Fix for inventory blocked from loading when address has 0 gold (but otherwise has items) 
  - Another previously undiscovered bug I found in testing.
- Added trace to try and catch cause of Infinity valuation on cv gold
  - This is hard to replicate but happens sometimes, I suspect its getting an odd value from dexscreener so hopefully this will allow a diagnosis next time I see it, and then I can put in a fix to handle it.